### PR TITLE
Refocus prompts and UI on liquor and wine store data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-# Warehouse Management ChatBot Project
+# Liquor and Wine Store ChatBot Project
 
-This project is designed to assist with warehouse management through a ChatBot application. It leverages support from OpenAI and Amazon LLM models to respond to various user queries related to warehouse management.
+This project is designed to assist with liquor and wine store management through a ChatBot application. It leverages support from OpenAI and Amazon LLM models to respond to various user queries related to store inventory and operations.
 
 ## Features
 
@@ -16,8 +16,8 @@ This project is designed to assist with warehouse management through a ChatBot a
 
 1. **Clone the repository:**
    ```bash
-   git clone https://github.com/samitugal/WarehouseManagerAI.git
-   cd warehouse-management-chatbot
+   git clone https://github.com/Trinadhreddy1184/WarehouseManagerAI_Updated.git
+   cd WarehouseManagerAI_Updated
    ```
 
 2. **Set up the Python environment:**
@@ -53,8 +53,8 @@ This project is designed to assist with warehouse management through a ChatBot a
 
 2. **Interacting with the ChatBot:**
    - Open the Streamlit application in your browser.
-   - Use the ChatBot interface to query the warehouse management system.
-   - The ChatBot will respond based on the combined power of OpenAI and Amazon LLM models, querying the PostgreSQL database and Pinecone embeddings as needed.
+     - Use the ChatBot interface to query the liquor and wine store inventory system.
+     - The ChatBot will respond based on the combined power of OpenAI and Amazon LLM models, querying the PostgreSQL database and Pinecone embeddings as needed.
 
 ## Project Structure
 

--- a/configs/prompts/sql_tool.md
+++ b/configs/prompts/sql_tool.md
@@ -1,3 +1,3 @@
-Use the SQL tool to query PostgreSQL.
+Use the SQL tool to query the liquor and wine store inventory in PostgreSQL.
 Query ONLY: app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 Never reference S3/CSV/DuckDB. Always LIMIT for examples.

--- a/configs/prompts/system.md
+++ b/configs/prompts/system.md
@@ -1,4 +1,4 @@
-You are the Inventory Management assistant for a PostgreSQL data warehouse.
+You are the Liquor and Wine Store inventory assistant for a PostgreSQL database.
 Answer by querying the database through the SQL tool. Do not mention S3, CSVs, or DuckDB.
 
 Use ONLY these read-only views:

--- a/prompts/agent_prompt_template.txt
+++ b/prompts/agent_prompt_template.txt
@@ -1,5 +1,5 @@
-# Agent Instruction (Inventory / SQL)
-You are an Inventory Management assistant that MUST use the SQL tool to answer.
+# Agent Instruction (Liquor and Wine Store / SQL)
+You are a Liquor and Wine Store inventory assistant that MUST use the SQL tool to answer.
 The database is PostgreSQL and exposes the following read-only views:
 - app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 

--- a/prompts/information_provider_template.txt
+++ b/prompts/information_provider_template.txt
@@ -1,4 +1,4 @@
-Use the SQL tool to query PostgreSQL.
+Use the SQL tool to query the liquor and wine store inventory in PostgreSQL.
 Query ONLY these views: app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 Never reference S3, CSV or DuckDB. Always LIMIT for preview outputs.
 

--- a/run_all.sh
+++ b/run_all.sh
@@ -304,7 +304,7 @@ docker exec -e PGPASSWORD="$POSTGRES_PASSWORD" wm_pgvector \
 # remove host dump to save space
 rm -f "$RAW_DUMP" "$SANITIZED" 2>/dev/null || true
 
-# ---------- 11) Host venv + Streamlit (background) ----------
+# ---------- 11) Host venv (dependencies only) ----------
 log "Preparing host venv for Streamlit…"
 if [ ! -d "$APP_DIR/.venv" ]; then sudo python3 -m venv "$APP_DIR/.venv"; fi
 sudo "$APP_DIR/.venv/bin/pip" install --upgrade pip >/dev/null
@@ -318,12 +318,8 @@ export DATA_BACKEND=postgres
 export DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${DB_PORT}/${POSTGRES_DB}"
 export SQLALCHEMY_DATABASE_URL="$DATABASE_URL"
 
-log "Launching Streamlit on 0.0.0.0:8501 (background)…"
-nohup sudo -E "$APP_DIR/.venv/bin/streamlit" run ui/streamlit_ui.py \
-  --server.port=8501 --server.address=0.0.0.0 \
-  > "$APP_DIR/logs/streamlit.log" 2>&1 &
-
-log "Streamlit PID: $!"
-log "Open:  http://$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4 2>/dev/null || echo localhost):8501"
-log "Tail:  tail -f $APP_DIR/logs/streamlit.log"
+# ---------- 12) Patch prompts/tools and launch UI ----------
+log "Patching prompts/tools and launching Streamlit…"
+bash scripts/patch_src_for_pg.sh
+bash scripts/fix_prompts_and_tools.sh
 

--- a/scripts/fix_prompts_and_tools.sh
+++ b/scripts/fix_prompts_and_tools.sh
@@ -12,8 +12,8 @@ echo "== 1) Update ALL candidate prompt files (root + src) with PG instructions"
 mkdir -p prompts src/prompts
 
 cat > prompts/agent_prompt_template.txt <<'TXT'
-# Agent Instruction (Inventory / SQL)
-You are an Inventory Management assistant that MUST use the SQL tool to answer.
+# Agent Instruction (Liquor and Wine Store / SQL)
+You are a Liquor and Wine Store inventory assistant that MUST use the SQL tool to answer.
 The database is PostgreSQL and exposes the following read-only views:
 - app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 
@@ -35,7 +35,7 @@ TXT
 cp prompts/agent_prompt_template.txt src/prompts/agent_prompt_template.txt
 
 cat > prompts/information_provider_template.txt <<'TXT'
-Use the SQL tool to query PostgreSQL.
+Use the SQL tool to query the liquor and wine store inventory in PostgreSQL.
 Query ONLY these views: app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 Never reference S3, CSV or DuckDB. Always LIMIT for preview outputs.
 
@@ -51,7 +51,7 @@ cp prompts/information_provider_template.txt src/prompts/information_provider_te
 # Optional system prompts some templates use
 mkdir -p configs/prompts
 cat > configs/prompts/system.md <<'MD'
-You are the Inventory Management assistant for a PostgreSQL data warehouse.
+You are the Liquor and Wine Store inventory assistant for a PostgreSQL database.
 Answer by querying the database through the SQL tool. Do not mention S3, CSVs, or DuckDB.
 
 Use ONLY these read-only views:

--- a/scripts/patch_src_for_pg.sh
+++ b/scripts/patch_src_for_pg.sh
@@ -8,7 +8,7 @@ mkdir -p configs/prompts
 
 echo "==> Write PG-first system prompts (new files)"
 cat > configs/prompts/system.md <<'MD'
-You are the Inventory Management assistant for a PostgreSQL data warehouse.
+You are the Liquor and Wine Store inventory assistant for a PostgreSQL database.
 Answer by querying the database through the SQL tool. Do not mention S3, CSVs, or DuckDB.
 
 Use ONLY these read-only views:
@@ -52,8 +52,8 @@ echo "==> Patch src/prompts templates (remove legacy references)"
 mkdir -p src/prompts
 if [ -f src/prompts/agent_prompt_template.txt ]; then cp -n src/prompts/agent_prompt_template.txt src/prompts/agent_prompt_template.txt.bak; fi
 cat > src/prompts/agent_prompt_template.txt <<'TXT'
-# Agent Instruction (Inventory / SQL)
-You are an Inventory Management assistant that MUST use the SQL tool to answer.
+# Agent Instruction (Liquor and Wine Store / SQL)
+You are a Liquor and Wine Store inventory assistant that MUST use the SQL tool to answer.
 The database is PostgreSQL and exposes the following views:
 - app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 

--- a/src/agents/agent_boot.py
+++ b/src/agents/agent_boot.py
@@ -5,7 +5,7 @@ from src.agents.tools_registry import TOOLS, TOOL_FUNCS
 
 def load_system_messages() -> list[dict[str, str]]:
     # Base system content (add your project-specific instructions here)
-    base = "You are the Warehouse Manager AI. Use tools when helpful."
+    base = "You are the Liquor and Wine Store Manager AI. Use tools when helpful."
     sql_rules = Path("prompts/system_sql.md").read_text(encoding="utf-8")
     return [{"role": "system", "content": base + "\n\n" + sql_rules}]
 

--- a/src/llm/tool_runner.py
+++ b/src/llm/tool_runner.py
@@ -14,7 +14,7 @@ def _system_prompt() -> str:
     if p.exists():
         return p.read_text(encoding="utf-8")
     return (
-        "You are an Inventory assistant with SQL tools over PostgreSQL. "
+        "You are a Liquor and Wine Store inventory assistant with SQL tools over PostgreSQL. "
         "Use ONLY app_vip_items, app_vip_products, app_vip_brands, app_inventory. "
         "Read-only queries; use LIMIT for previews."
     )

--- a/src/prompts/agent_prompt_template.txt
+++ b/src/prompts/agent_prompt_template.txt
@@ -1,5 +1,5 @@
-# Agent Instruction (Inventory / SQL)
-You are an Inventory Management assistant that MUST use the SQL tool to answer.
+# Agent Instruction (Liquor and Wine Store / SQL)
+You are a Liquor and Wine Store inventory assistant that MUST use the SQL tool to answer.
 The database is PostgreSQL and exposes the following read-only views:
 - app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 

--- a/src/prompts/information_provider_template.txt
+++ b/src/prompts/information_provider_template.txt
@@ -1,4 +1,4 @@
-Use the SQL tool to query PostgreSQL.
+Use the SQL tool to query the liquor and wine store inventory in PostgreSQL.
 Query ONLY these views: app_vip_items, app_vip_products, app_vip_brands, app_vip_suppliers, app_inventory.
 Never reference S3, CSV or DuckDB. Always LIMIT for preview outputs.
 

--- a/ui/streamlit_ui.py
+++ b/ui/streamlit_ui.py
@@ -19,9 +19,9 @@ from streamlit_chat import message
 from src.llm.ModelManager import ModelManager
 from src.config_defs.llm_config_defs import LLMMainConfig
 
-st.set_page_config(page_title="Inventory Management Chatbot", layout="wide")
+st.set_page_config(page_title="Liquor and Wine Store Chatbot", layout="wide")
 
-st.header("Inventory Management Chatbot")
+st.header("Liquor and Wine Store Chatbot")
 
 # --- load config/model ---
 llm_config: LLMMainConfig = LLMMainConfig.from_file(os.getenv("LLM_CONFIG_PATH"))


### PR DESCRIPTION
## Summary
- Rebrand prompts, docs, and UI for a liquor and wine store inventory
- Add automated prompt and tool patching to the `run_all.sh` workflow so the app loads S3 SQL dumps into Postgres and launches with updated guidance

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `bash -n run_all.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b127cc7bc0832282ce518d202a52e5