### PR TITLE
refactor: replace match statement for python 3.9

### DIFF
--- a/src/llm/ModelManager.py
+++ b/src/llm/ModelManager.py
@@ -14,13 +14,21 @@ class ModelManager:
 
     @staticmethod
     def new_instance_from_config(config: LLMMainConfig) -> "ModelManager":
-        match config.llm.llm_tag:
-            case LLMTag.BEDROCK:
-                return ModelManager(config, Bedrock(config))
-            # case LLMTag.OPENAI:
-            #     return ModelManager(config, OpenAIModel(config))
-            case _:
-                raise ValueError(f"Invalid LLM tag: {config.llm.llm_tag}")
+        """Create a new ``ModelManager`` based on the provided configuration.
+
+        The previous implementation used Python's ``match`` statement, which is
+        only available from Python 3.10 onwards.  This caused a ``SyntaxError``
+        when running the code in environments that rely on older Python
+        versions, such as 3.9.  To maintain compatibility, the pattern matching
+        has been rewritten using standard ``if``/``elif`` logic.
+        """
+        tag = config.llm.llm_tag
+        if tag == LLMTag.BEDROCK:
+            return ModelManager(config, Bedrock(config))
+        # elif tag == LLMTag.OPENAI:
+        #     return ModelManager(config, OpenAIModel(config))
+        else:
+            raise ValueError(f"Invalid LLM tag: {tag}")
 
     def provide_information(
         self,


### PR DESCRIPTION
## Summary
- avoid SyntaxError on Python <3.10 by replacing `match` with `if/elif` in ModelManager

## Testing
- `python -m py_compile src/llm/ModelManager.py && echo py_compile_passed`


------
https://chatgpt.com/codex/tasks/task_e_68b207df55488322b91f1b6d278f00f5